### PR TITLE
Fix circuit game nav link text

### DIFF
--- a/home
+++ b/home
@@ -100,7 +100,7 @@
       <li><a href="index.html">Home</a></li>
       <li><a href="#lessons">Lesson Plans</a></li>
       <li><a href="#resources">Resources</a></li>
-      <li><a href="circuit_symbol_game.html">Games</a></li>
+      <li><a href="circuit_symbol_game.html">Circuit Game</a></li>
       <li><a href="#contact">Contact</a></li>
     </ul>
   </nav>

--- a/index.html
+++ b/index.html
@@ -100,8 +100,8 @@
        <li><a href="index.html">Home</a></li>
        <li><a href="#lessons">Lesson Plans</a></li>
        <li><a href="#resources">Resources</a></li>
-       <li><a href="circuit_symbol_game.html">Games</a></li>
-       <li><a href="games.html">Games</a></li>
+      <li><a href="circuit_symbol_game.html">Circuit Game</a></li>
+      <li><a href="games.html">Games</a></li>
        <li><a href="#contact">Contact</a></li>
      </ul>
    </nav>


### PR DESCRIPTION
## Summary
- change nav link text to 'Circuit Game' in `index.html` and `home`
- verify only one 'Games' nav item remains

## Testing
- `grep -n "<a.*Games" -n index.html`


------
https://chatgpt.com/codex/tasks/task_e_683f9a03b1b08320804a1f5e55a152b8