### PR TITLE
Increment score on hit

### DIFF
--- a/Cannon_duel/index.html
+++ b/Cannon_duel/index.html
@@ -101,7 +101,10 @@
     function segmentHitsTower(x0,y0,x1,y1){const t=towers[player===1?1:0],rect={x:t.x-towerW/2,y:t.y,w:towerW,h:towerH},steps=Math.ceil(Math.hypot(x1-x0,y1-y0)/2);for(let i=0;i<=steps;i++){const u=i/steps,x=x0+(x1-x0)*u,y=y0+(y1-y0)*u; if(x>=rect.x&&x<=rect.x+rect.w&&y>=rect.y&&y<=rect.y+rect.h) return true;} return false;}
 
     function endTurn(hit){cancelAnimationFrame(animId);carveCrater(proj.x);drawScene();
-      if(hit){ splashText.textContent=`Player ${player} Wins!`; splash.style.display='flex'; }
+      if(hit){
+        if(player===1&&hit) score1++; else if(player===2&&hit) score2++;
+        updateScore();
+        splashText.textContent=`Player ${player} Wins!`; splash.style.display='flex'; }
       else{ setTimeout(()=>{player=3-player;msgEl.textContent=`Miss! Player ${player}'s turn`;btn.disabled=false;drawScene();turns++;},100);}
       proj=null;trail=[]; }
 


### PR DESCRIPTION
## Summary
- update the score inside `endTurn(hit)` when a player hits
- refresh the scoreboard immediately after the score update

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f9a14cda48320915d3baa3dd6d551