### PR TITLE
Add Cannon Duel game card

### DIFF
--- a/games.html
+++ b/games.html
@@ -130,6 +130,11 @@
         <a href="https://rrmudry.github.io/Apollo13/index.html" target="_blank" rel="noopener">Play Now</a>
       </div>
       <div class="card">
+        <h3>💣 Cannon Duel</h3>
+        <p>Challenge a friend in this 2‑player projectile showdown.</p>
+        <a href="Cannon_duel/index.html" target="_blank" rel="noopener">Play Now</a>
+      </div>
+      <div class="card">
         <h3>📈 Coming Soon: Projectile Motion Simulator</h3>
         <p>Launch, adjust angle, and predict the landing spot.</p>
         <a href="#">Stay Tuned</a>


### PR DESCRIPTION
## Summary
- add Cannon Duel card with link to game on games page

## Testing
- `tidy -errors -q games.html`
- `tidy -errors -q Cannon_duel/index.html`

------
https://chatgpt.com/codex/tasks/task_e_683f9d78efe08320ab1673ee78a5f0e4