### PR TITLE
Add placeholder unit menu to Lesson Plans page

### DIFF
--- a/lessons.html
+++ b/lessons.html
@@ -31,9 +31,16 @@
   <h1>NGSS Lesson Plans</h1>
   <p>Browse downloadable materials for class activities.</p>
   <ul class="lessons">
-    <li>Introduction to Circuits - <a href="#" class="download">PDF</a></li>
-    <li>Projectile Motion Lab - <a href="#" class="download">PDF</a></li>
-    <li>Energy Conservation - <a href="#" class="download">PDF</a></li>
+    <li><a href="#" class="download">Unit 1</a></li>
+    <li><a href="#" class="download">Unit 2</a></li>
+    <li><a href="#" class="download">Unit 3</a></li>
+    <li><a href="#" class="download">Unit 4</a></li>
+    <li><a href="#" class="download">Unit 5</a></li>
+    <li><a href="#" class="download">Unit 6</a></li>
+    <li><a href="#" class="download">Unit 7</a></li>
+    <li><a href="#" class="download">Unit 8</a></li>
+    <li><a href="#" class="download">Unit 9</a></li>
+    <li><a href="#" class="download">Unit 10</a></li>
   </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace sample lessons with placeholder unit links from Unit 1 through Unit 10 on Lesson Plans page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68912f754e68832081ef0a7b64bde6af