### PR TITLE
Revamp homepage with responsive layout and navigation

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Accessibility | Mr. Mudry's Physics</title>
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="apple-touch-icon.svg">
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<header class="site-header">
+  <div class="container nav">
+    <a class="brand" href="/">
+      <img src="panther-logo.svg" alt="Orange High Panthers logo" width="40" height="40">
+      <span>Mr. Mudry’s Physics</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="navmenu">Menu</button>
+    <nav id="navmenu" class="menu">
+      <a href="index.html">Home</a>
+      <a href="lesson-plans.html">Lesson Plans</a>
+      <a href="resources.html">Resources</a>
+      <a href="circuit-game.html">Circuit Game</a>
+      <a href="games.html">Games</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </div>
+</header>
+
+<section class="container section">
+  <h1>Accessibility</h1>
+  <p>We're working to ensure our site is accessible to all. Please reach out with any issues.</p>
+</section>
+
+<footer class="site-footer">
+  <div class="container foot">
+    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
+    <nav class="foot-links">
+      <a href="contact.html">Contact</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="accessibility.html" class="active">Accessibility</a>
+    </nav>
+  </div>
+</footer>
+
+<script defer>
+const b=document.querySelector(".nav-toggle"),m=document.getElementById("navmenu");
+b?.addEventListener("click",()=>{const o=m.dataset.open==="true";m.dataset.open=!o;b.setAttribute("aria-expanded",(!o).toString());});
+</script>
+</body>
+</html>

--- a/apple-touch-icon.svg
+++ b/apple-touch-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="#ff6a00" />
+  <text x="50" y="70" font-size="60" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif">P</text>
+</svg>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,78 @@
+:root{
+  --brand: #ff6a00;
+  --brand-dark:#cc5200;
+  --ink:#111;
+  --ink-dim:#444;
+  --bg:#ffffff;
+  --bg-muted:#f7f7f7;
+  --card:#ffffff;
+  --ring: var(--brand);
+  --radius: 16px;
+  --shadow: 0 6px 24px rgba(0,0,0,.08);
+  --space-1: .5rem;
+  --space-2: .75rem;
+  --space-3: 1rem;
+  --space-4: 1.5rem;
+  --space-5: 2rem;
+}
+html{box-sizing:border-box}
+*,*:before,*:after{box-sizing:inherit}
+body{
+  margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+  color:var(--ink); background:var(--bg); line-height:1.5;
+}
+.container{max-width:1100px; margin:auto; padding:0 var(--space-3)}
+h1,h2{font-weight:600; letter-spacing:.2px}
+
+.site-header{position:sticky; top:0; background:#fff; border-bottom:1px solid #eee; z-index:10}
+.nav{display:flex; align-items:center; gap:var(--space-3); padding:var(--space-3) 0}
+.brand{display:flex; align-items:center; gap:.6rem; text-decoration:none; color:var(--ink); font-weight:700}
+.menu{display:flex; gap:var(--space-3)}
+.menu a{padding:.5rem .75rem; border-radius:10px; text-decoration:none; color:var(--ink-dim)}
+.menu a:hover, .menu a.active{background:var(--bg-muted); color:var(--ink)}
+.nav-toggle{display:none}
+@media (max-width: 800px){
+  .menu{display:none; flex-direction:column; background:#fff; padding:var(--space-3); border:1px solid #eee; border-radius:12px; position:absolute; right:1rem; top:64px; box-shadow:var(--shadow)}
+  .nav-toggle{display:inline-flex; margin-left:auto}
+  .menu[data-open="true"]{display:flex}
+}
+
+.hero{background:linear-gradient(180deg, rgba(255,106,0,.08), transparent 60%); padding:var(--space-5) 0}
+.hero h1{font-size:clamp(28px, 4.5vw, 44px); margin:0 0 .25rem}
+.hero .subtitle{margin:0 0 var(--space-4); color:var(--ink-dim); font-size:1.1rem}
+.btn{display:inline-block; padding:.75rem 1rem; border-radius:999px; border:1px solid #ddd; text-decoration:none; color:var(--ink)}
+.btn.primary{background:var(--brand); border-color:var(--brand); color:#fff}
+.btn:hover{transform:translateY(-1px); box-shadow:var(--shadow)}
+.cta-row{display:flex; gap:var(--space-3); flex-wrap:wrap}
+
+.section{padding: var(--space-5) 0}
+.announcements{list-style:none; padding:0; margin:var(--space-3) 0 0; display:grid; gap:var(--space-2)}
+.announcements li{background:var(--card); border:1px solid #eee; border-radius:12px; padding:var(--space-3); display:flex; gap:1rem; align-items:flex-start}
+.announcements time{background:var(--bg-muted); border-radius:999px; padding:.25rem .6rem; font-variant-numeric: tabular-nums; color:var(--ink)}
+
+.grid{display:grid; gap:var(--space-3); grid-template-columns: repeat(12, 1fr)}
+.card{grid-column: span 12; padding:var(--space-4); border:1px solid #eee; border-radius:var(--radius); box-shadow:var(--shadow); background:var(--card)}
+.card h3{margin:.25rem 0 .5rem; font-size:1.25rem}
+.card p{margin:0 0 var(--space-3); color:var(--ink-dim)}
+@media(min-width:720px){ .card{grid-column: span 6} }
+@media(min-width:1024px){ .card{grid-column: span 4} }
+.card:hover{transform:translateY(-2px)}
+
+.site-footer{border-top:1px solid #eee; background:#fff}
+.foot{display:flex; flex-wrap:wrap; align-items:center; gap:var(--space-3); padding:var(--space-4) 0; color:#666}
+.foot-links{margin-left:auto; display:flex; gap:var(--space-3)}
+.foot a{color:#666; text-decoration:none}
+.foot a:hover{color:var(--ink)}
+
+a, button{outline:none}
+a:focus-visible, button:focus-visible{box-shadow:0 0 0 3px rgba(255,106,0,.35)}
+.lessons{list-style:none;padding:0;margin:var(--space-3) 0;display:grid;gap:var(--space-2)}
+.lessons li a{text-decoration:none;color:var(--brand-dark)}
+.lessons li a:hover{text-decoration:underline}
+#game{max-width:500px;margin:auto;background:#fff;padding:var(--space-4);border-radius:10px;box-shadow:0 2px 6px rgba(0,0,0,.1);text-align:center}
+#symbol svg{width:150px;height:auto;margin:var(--space-3) 0}
+.option-btn{display:block;width:100%;margin:.5rem 0;padding:.75rem;font-size:1rem;border:none;border-radius:5px;cursor:pointer;background:#e0e0e0}
+.option-btn:hover{background:#d5d5d5}
+.correct{background:#a5d6a7!important}
+.incorrect{background:#ef9a9a!important}
+#progress{margin-top:1rem;font-weight:bold}

--- a/circuit-game.html
+++ b/circuit-game.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Electronic Symbols Quiz Game</title>
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="apple-touch-icon.svg">
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<header class="site-header">
+  <div class="container nav">
+    <a class="brand" href="/">
+      <img src="panther-logo.svg" alt="Orange High Panthers logo" width="40" height="40">
+      <span>Mr. Mudry’s Physics</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="navmenu">Menu</button>
+    <nav id="navmenu" class="menu">
+      <a href="index.html">Home</a>
+      <a href="lesson-plans.html">Lesson Plans</a>
+      <a href="resources.html">Resources</a>
+      <a href="circuit-game.html" class="active">Circuit Game</a>
+      <a href="games.html">Games</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </div>
+</header>
+
+<section class="container section">
+  <div id="game">
+    <h1>Electronic Symbols Quiz</h1>
+    <div id="symbol"></div>
+    <div id="options"></div>
+    <div id="progress"></div>
+  </div>
+</section>
+
+<footer class="site-footer">
+  <div class="container foot">
+    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
+    <nav class="foot-links">
+      <a href="contact.html">Contact</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="accessibility.html">Accessibility</a>
+    </nav>
+  </div>
+</footer>
+
+<script defer>
+const b=document.querySelector('.nav-toggle'),m=document.getElementById('navmenu');
+b?.addEventListener('click',()=>{const o=m.dataset.open==="true";m.dataset.open=!o;b.setAttribute('aria-expanded',(!o).toString());});
+</script>
+<script defer>
+document.addEventListener('DOMContentLoaded',()=>{
+  const symbols=[
+    {name:'Resistor',svg:'<svg viewBox="0 0 100 50"><polyline points="0,25 10,25 15,15 25,35 35,15 45,35 55,15 65,35 75,15 85,35 100,25" stroke="black" fill="none" stroke-width="2"/></svg>'},
+    {name:'Capacitor',svg:'<svg viewBox="0 0 100 50"><line x1="40" y1="10" x2="40" y2="40" stroke="black" stroke-width="2"/><line x1="60" y1="10" x2="60" y2="40" stroke="black" stroke-width="2"/><line x1="0" y1="25" x2="40" y2="25" stroke="black" stroke-width="2"/><line x1="60" y1="25" x2="100" y2="25" stroke="black" stroke-width="2"/></svg>'},
+    {name:'Inductor',svg:'<svg viewBox="0 0 100 50"><path d="M0,25 a12,12 0 0,1 24,0 a12,12 0 0,1 24,0 a12,12 0 0,1 24,0 a12,12 0 0,1 24,0" stroke="black" fill="none" stroke-width="2"/></svg>'},
+    {name:'Ground',svg:'<svg viewBox="0 0 100 50"><line x1="50" y1="5" x2="50" y2="20" stroke="black" stroke-width="2"/><line x1="35" y1="20" x2="65" y2="20" stroke="black" stroke-width="2"/><line x1="40" y1="25" x2="60" y2="25" stroke="black" stroke-width="2"/><line x1="45" y1="30" x2="55" y2="30" stroke="black" stroke-width="2"/></svg>'},
+    {name:'Diode',svg:'<svg viewBox="0 0 100 50"><line x1="0" y1="25" x2="40" y2="25" stroke="black" stroke-width="2"/><polygon points="40,10 80,25 40,40" stroke="black" fill="none" stroke-width="2"/><line x1="80" y1="10" x2="80" y2="40" stroke="black" stroke-width="2"/><line x1="80" y1="25" x2="100" y2="25" stroke="black" stroke-width="2"/></svg>'},
+    {name:'LED',svg:'<svg viewBox="0 0 120 60"><line x1="0" y1="30" x2="40" y2="30" stroke="black" stroke-width="2"/><polygon points="40,15 80,30 40,45" stroke="black" fill="none" stroke-width="2"/><line x1="80" y1="15" x2="80" y2="45" stroke="black" stroke-width="2"/><path d="M90,10 l15,10 M90,20 l15,10" stroke="black" stroke-width="2"/></svg>'},
+    {name:'Switch',svg:'<svg viewBox="0 0 100 50"><line x1="0" y1="25" x2="40" y2="25" stroke="black" stroke-width="2"/><line x1="40" y1="25" x2="60" y2="10" stroke="black" stroke-width="2"/><line x1="60" y1="25" x2="100" y2="25" stroke="black" stroke-width="2"/></svg>'},
+    {name:'Battery',svg:'<svg viewBox="0 0 100 50"><line x1="0" y1="25" x2="35" y2="25" stroke="black" stroke-width="2"/><line x1="35" y1="15" x2="35" y2="35" stroke="black" stroke-width="4"/><line x1="55" y1="10" x2="55" y2="40" stroke="black" stroke-width="2"/><line x1="55" y1="25" x2="100" y2="25" stroke="black" stroke-width="2"/></svg>'},
+    {name:'Lamp',svg:'<svg viewBox="0 0 100 50"><circle cx="50" cy="25" r="20" stroke="black" fill="none" stroke-width="2"/><line x1="40" y1="15" x2="60" y2="35" stroke="black" stroke-width="2"/><line x1="60" y1="15" x2="40" y2="35" stroke="black" stroke-width="2"/></svg>'},
+    {name:'Motor',svg:'<svg viewBox="0 0 100 50"><circle cx="50" cy="25" r="20" stroke="black" fill="none" stroke-width="2"/><text x="50" y="30" text-anchor="middle" font-size="20">M</text></svg>'}
+  ];
+  let currentIndex=0,score=0;const total=symbols.length;
+  function shuffle(arr){return arr.sort(()=>Math.random()-0.5);}
+  function startGame(){currentIndex=0;score=0;shuffle(symbols);showQuestion();}
+  function showQuestion(){const gameEl=document.getElementById('game');if(currentIndex>=total){gameEl.innerHTML=`<h2>Your Score: ${score} / ${total}</h2><button onclick="startGame()">Play Again</button>`;return;}const symbol=symbols[currentIndex];document.getElementById('symbol').innerHTML=symbol.svg;const names=shuffle([symbol.name,...symbols.filter(s=>s.name!==symbol.name).slice(0,3).map(s=>s.name)]);const optionsDiv=document.getElementById('options');optionsDiv.innerHTML='';names.forEach(name=>{const btn=document.createElement('button');btn.textContent=name;btn.className='option-btn';btn.onclick=()=>handleAnswer(name===symbol.name,btn);optionsDiv.appendChild(btn);});document.getElementById('progress').textContent=`Question ${currentIndex+1} of ${total}`;}
+  function handleAnswer(isCorrect,button){if(isCorrect){score++;button.classList.add('correct');}else{button.classList.add('incorrect');}document.querySelectorAll('.option-btn').forEach(b=>b.disabled=true);currentIndex++;setTimeout(showQuestion,1000);}
+  startGame();
+});
+</script>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Contact | Mr. Mudry's Physics</title>
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="apple-touch-icon.svg">
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<header class="site-header">
+  <div class="container nav">
+    <a class="brand" href="/">
+      <img src="panther-logo.svg" alt="Orange High Panthers logo" width="40" height="40">
+      <span>Mr. Mudry’s Physics</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="navmenu">Menu</button>
+    <nav id="navmenu" class="menu">
+      <a href="index.html">Home</a>
+      <a href="lesson-plans.html">Lesson Plans</a>
+      <a href="resources.html">Resources</a>
+      <a href="circuit-game.html">Circuit Game</a>
+      <a href="games.html">Games</a>
+      <a href="contact.html" class="active">Contact</a>
+    </nav>
+  </div>
+</header>
+
+<section class="container section">
+  <h1>Contact</h1>
+  <p>Questions? Ideas? Feedback? <a href="mailto:mudry@school.edu">Email Mr. Mudry</a></p>
+</section>
+
+<footer class="site-footer">
+  <div class="container foot">
+    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
+    <nav class="foot-links">
+      <a href="contact.html" class="active">Contact</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="accessibility.html">Accessibility</a>
+    </nav>
+  </div>
+</footer>
+
+<script defer>
+const b=document.querySelector(".nav-toggle"),m=document.getElementById("navmenu");
+b?.addEventListener("click",()=>{const o=m.dataset.open==="true";m.dataset.open=!o;b.setAttribute("aria-expanded",(!o).toString());});
+</script>
+</body>
+</html>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="#ff6a00" />
+  <text x="50" y="70" font-size="60" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif">P</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,158 +1,92 @@
 <!DOCTYPE html>
- <html lang="en">
- <head>
-   <meta charset="UTF-8">
-   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-   <title>Mr. Mudry's Physics Class</title>
-   <style>
-     /* Reset & base */
-     * { box-sizing: border-box; margin: 0; padding: 0; }
-     body {
-       font-family: Arial, sans-serif;
-       background: #000;
-       color: #fff;
-       line-height: 1.6;
-     }
-     nav { background: #111; padding: 1rem 2rem; display: flex; justify-content: space-between; align-items: center; }
-     .logo { font-size: 1.8rem; font-weight: 700; color: #FF6600; letter-spacing: 1px; }
-     nav ul { list-style: none; display: flex; }
-     nav ul li { margin-left: 1.5rem; }
-     nav ul li a { color: #FF6600; text-decoration: none; font-weight: 600; transition: color 0.2s; }
-     nav ul li a:hover { color: #FFA633; }
- 
-     /* Hero Banner */
-     .hero {
-       position: relative;
-       background: url('OrangeHS_PantherMark.png') center/cover no-repeat;
-       height: 60vh;
-       display: flex;
-       align-items: center;
-       justify-content: center;
-       text-align: center;
-     }
-     .hero::after {
-       content: '';
-       position: absolute; top: 0; left: 0;
-       width: 100%; height: 100%;
-       background: rgba(0,0,0,0.6);
-       z-index: 1;
-     }
-     .hero-content {
-       position: relative;
-       z-index: 2;
-       color: #FF6600;
-       display: flex;
-       flex-direction: column;
-       align-items: center;
-       gap: 1rem;
-     }
-     .hero-logo {
-       width: 180px;
-       height: auto;
-       border: 4px solid #FF6600;
-       border-radius: 8px;
-     }
-     .hero-content h1 {
-       font-size: 3.5rem;
-       font-weight: 800;
-       text-shadow: 0 2px 6px rgba(0,0,0,0.7);
-       margin: 0;
-     }
-     .hero-content p {
-       font-size: 1.4rem;
-       font-weight: 500;
-       margin: 0;
-     }
- 
-     /* Main container */
-     .container {
-       max-width: 1100px;
-       margin: -3rem auto 2rem;
-       padding: 0 1rem;
-     }
-     .announcements { background: #111; padding: 1.5rem; border-radius: 8px; margin-bottom: 2rem; }
-     .announcements h2 { color: #FF6600; font-size: 2rem; font-weight: 700; margin-bottom: 0.75rem; }
-     .announcements ul { list-style: none; }
-     .announcements li { margin-bottom: 0.75rem; font-size: 1.1rem; font-weight: 500; }
-     .announcements li:before { content: '🔥'; margin-right: 0.5rem; }
- 
-     .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1.5rem; }
-     .card { background: #111; border: 2px solid #FF6600; border-radius: 8px; padding: 1.75rem; text-align: center; transition: transform 0.2s; }
-     .card:hover { transform: translateY(-5px); }
-     .card h3 { margin-bottom: 0.75rem; color: #FF6600; font-size: 1.5rem; font-weight: 700; }
-     .card p { margin-bottom: 1.25rem; font-size: 1.1rem; font-weight: 500; }
-     .card a { display: inline-block; padding: 0.6rem 1.2rem; background: #FF6600; color: #000; font-weight: 600; text-decoration: none; border-radius: 4px; transition: background 0.2s; }
-     .card a:hover { background: #cc5500; }
- 
-     #contact { margin-top: 2rem; }
-     #contact h2 { color: #FF6600; font-size: 2rem; font-weight: 700; margin-bottom: 0.5rem; }
-     #contact p { font-size: 1.1rem; font-weight: 500; }
-     #contact a { color: #FFA633; font-weight: 600; text-decoration: none; }
- 
-     footer { background: #111; color: #fff; text-align: center; padding: 1rem; margin-top: 2rem; }
-     footer p { font-size: 0.9rem; font-weight: 500; }
-   </style>
- </head>
- <body>
-   <nav>
-     <div class="logo">Mr. Mudry's Physics Class</div>
-     <ul>
-       <li><a href="index.html">Home</a></li>
-      <li><a href="lessons.html">Lesson Plans</a></li>
-      <li><a href="resources.html">Resources</a></li>
-      <li><a href="circuit_symbol_game.html">Circuit Game</a></li>
-      <li><a href="games.html">Games</a></li>
-       <li><a href="#contact">Contact</a></li>
-     </ul>
-   </nav>
- 
-   <section class="hero">
-     <div class="hero-content">
-       <img src="OrangeHS_PantherMark.png" alt="Orange High School Panther Logo" class="hero-logo">
-       <h1>Unleash Your Inner Scientist!</h1>
-       <p>Explore. Experiment. Excel.</p>
-     </div>
-   </section>
- 
-   <div class="container">
-     <section class="announcements">
-       <h2>What’s Happening</h2>
-       <ul>
-         <li>Spring Break: April 20–24, 2025 — Recharge & get inspired!</li>
-         <li>Lab Reports Due: May 1, 2025 — Show off your data skills.</li>
-         <li>Physics Fair: May 15, 2025 — Bring your best experiment!</li>
-       </ul>
-     </section>
- 
-     <section id="resources">
-       <h2 style="color:#FF6600; font-size:2rem; font-weight:700;">Quick Action Cards</h2>
-       <div class="cards">
-         <div class="card">
-           <h3>🔥 NGSS Lesson Plans</h3>
-           <p>Dive into hands-on, real-world physics challenges.</p>
-          <a href="lessons.html">Get Started</a>
-         </div>
-         <div class="card">
-           <h3>⚡ Circuit Game</h3>
-           <p>Put your skills to the test in our electrifying quiz!</p>
-           <a href="circuit_symbol_game.html">Play Now</a>
-         </div>
-         <div class="card">
-           <h3>📚 Extra Resources</h3>
-           <p>Stay current with science news, videos, and more.</p>
-          <a href="resources.html">Explore</a>
-         </div>
-       </div>
-     </section>
- 
-     <section id="contact">
-       <h2>Get in Touch</h2>
-       <p>Questions? Ideas? Feedback? <a href="mailto:mudry@school.edu">Email Mr. Mudry</a></p>
-     </section>
-   </div>
- 
-   <footer>
-     <p>&copy; 2025 Mr. Mudry. All rights reserved. | Orange High School Panthers 🐾</p>
-   </footer>
- </body>
- </html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Mr. Mudry's Physics</title>
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="apple-touch-icon.svg">
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<header class="site-header">
+  <div class="container nav">
+    <a class="brand" href="/">
+      <img src="panther-logo.svg" alt="Orange High Panthers logo" width="40" height="40">
+      <span>Mr. Mudry’s Physics</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="navmenu">Menu</button>
+    <nav id="navmenu" class="menu">
+      <a href="index.html" class="active">Home</a>
+      <a href="lesson-plans.html">Lesson Plans</a>
+      <a href="resources.html">Resources</a>
+      <a href="circuit-game.html">Circuit Game</a>
+      <a href="games.html">Games</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </div>
+</header>
+
+<section class="hero">
+  <div class="container">
+    <h1>Unleash Your Inner Scientist!</h1>
+    <p class="subtitle">Explore. Experiment. Excel.</p>
+    <div class="cta-row">
+      <a class="btn primary" href="lesson-plans.html">NGSS Lesson Plans</a>
+      <a class="btn" href="circuit-game.html">Play Circuit Game</a>
+    </div>
+  </div>
+</section>
+
+<section class="container section">
+  <h2>What’s Happening</h2>
+  <ul class="announcements">
+    <li><time datetime="2025-04-20">Apr 20–24</time> Spring Break — Recharge & get inspired!</li>
+    <li><time datetime="2025-05-01">May 1</time> Lab Reports Due — Show off your data skills.</li>
+    <li><time datetime="2025-05-15">May 15</time> Physics Fair — Bring your best experiment!</li>
+  </ul>
+</section>
+
+<section class="container section">
+  <h2>Quick Action</h2>
+  <div class="grid">
+    <article class="card">
+      <h3>NGSS Lesson Plans</h3>
+      <p>Dive into hands-on, real-world physics challenges.</p>
+      <a class="btn primary" href="lesson-plans.html">Get Started</a>
+    </article>
+    <article class="card">
+      <h3>⚡ Circuit Game</h3>
+      <p>Put your skills to the test in our electrifying quiz!</p>
+      <a class="btn" href="circuit-game.html">Play Now</a>
+    </article>
+    <article class="card">
+      <h3>Extra Resources</h3>
+      <p>Stay current with science news, videos, and more.</p>
+      <a class="btn" href="resources.html">Explore</a>
+    </article>
+  </div>
+</section>
+
+<section id="contact" class="container section">
+  <h2>Get in Touch</h2>
+  <p>Questions? Ideas? Feedback? <a href="mailto:mudry@school.edu">Email Mr. Mudry</a></p>
+</section>
+
+<footer class="site-footer">
+  <div class="container foot">
+    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
+    <nav class="foot-links">
+      <a href="contact.html">Contact</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="accessibility.html">Accessibility</a>
+    </nav>
+  </div>
+</footer>
+
+<script defer>
+const b=document.querySelector(".nav-toggle"),m=document.getElementById("navmenu");
+b?.addEventListener("click",()=>{const o=m.dataset.open==="true";m.dataset.open=!o;b.setAttribute("aria-expanded",(!o).toString());});
+</script>
+</body>
+</html>

--- a/lesson-plans.html
+++ b/lesson-plans.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>NGSS Lesson Plans | Mr. Mudry's Physics</title>
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="apple-touch-icon.svg">
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<header class="site-header">
+  <div class="container nav">
+    <a class="brand" href="/">
+      <img src="panther-logo.svg" alt="Orange High Panthers logo" width="40" height="40">
+      <span>Mr. Mudry’s Physics</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="navmenu">Menu</button>
+    <nav id="navmenu" class="menu">
+      <a href="index.html">Home</a>
+      <a href="lesson-plans.html" class="active">Lesson Plans</a>
+      <a href="resources.html">Resources</a>
+      <a href="circuit-game.html">Circuit Game</a>
+      <a href="games.html">Games</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </div>
+</header>
+
+<section class="container section">
+  <h1>NGSS Lesson Plans</h1>
+  <p>Browse downloadable materials for class activities.</p>
+  <ul class="lessons">
+    <li><a href="unit1.html">Unit 1</a></li>
+    <li><a href="#">Unit 2</a></li>
+    <li><a href="#">Unit 3</a></li>
+    <li><a href="#">Unit 4</a></li>
+    <li><a href="#">Unit 5</a></li>
+    <li><a href="#">Unit 6</a></li>
+    <li><a href="#">Unit 7</a></li>
+    <li><a href="#">Unit 8</a></li>
+    <li><a href="#">Unit 9</a></li>
+    <li><a href="#">Unit 10</a></li>
+  </ul>
+</section>
+
+<footer class="site-footer">
+  <div class="container foot">
+    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
+    <nav class="foot-links">
+      <a href="contact.html">Contact</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="accessibility.html">Accessibility</a>
+    </nav>
+  </div>
+</footer>
+
+<script defer>
+const b=document.querySelector('.nav-toggle'),m=document.getElementById('navmenu');
+b?.addEventListener('click',()=>{const o=m.dataset.open==="true";m.dataset.open=!o;b.setAttribute('aria-expanded',(!o).toString());});
+</script>
+</body>
+</html>

--- a/panther-logo.svg
+++ b/panther-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="#ff6a00" />
+  <text x="50" y="70" font-size="60" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif">P</text>
+</svg>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Privacy Policy | Mr. Mudry's Physics</title>
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="apple-touch-icon.svg">
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<header class="site-header">
+  <div class="container nav">
+    <a class="brand" href="/">
+      <img src="panther-logo.svg" alt="Orange High Panthers logo" width="40" height="40">
+      <span>Mr. Mudry’s Physics</span>
+    </a>
+    <button class="nav-toggle" aria-expanded="false" aria-controls="navmenu">Menu</button>
+    <nav id="navmenu" class="menu">
+      <a href="index.html">Home</a>
+      <a href="lesson-plans.html">Lesson Plans</a>
+      <a href="resources.html">Resources</a>
+      <a href="circuit-game.html">Circuit Game</a>
+      <a href="games.html">Games</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </div>
+</header>
+
+<section class="container section">
+  <h1>Privacy Policy</h1>
+  <p>Privacy details coming soon.</p>
+</section>
+
+<footer class="site-footer">
+  <div class="container foot">
+    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
+    <nav class="foot-links">
+      <a href="contact.html">Contact</a>
+      <a href="privacy.html" class="active">Privacy</a>
+      <a href="accessibility.html">Accessibility</a>
+    </nav>
+  </div>
+</footer>
+
+<script defer>
+const b=document.querySelector(".nav-toggle"),m=document.getElementById("navmenu");
+b?.addEventListener("click",()=>{const o=m.dataset.open==="true";m.dataset.open=!o;b.setAttribute("aria-expanded",(!o).toString());});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace large binary logo with lightweight SVG favicon and touch icon; update all pages to use the shared header logo.
- Standardize lesson plans and circuit game pages with new navigation/footer and move their styles into the global stylesheet.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a901dd16c8320a9d10556f8217715