### PR TITLE
Apply shared black-and-orange theme

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -9,19 +9,7 @@
   <link rel="stylesheet" href="assets/theme.css"/>
 </head>
 <body>
-<header class="site-header" role="banner">
-  <div class="container nav">
-    <a class="brand" href="index.html"><img src="panther-logo.svg" alt="Orange High Panthers logo"><span>Mr. Mudry’s Physics</span></a>
-    <nav class="menu" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="lesson-plans.html">Lesson Plans</a>
-      <a href="resources.html">Resources</a>
-      <a href="circuit-game.html">Circuit Game</a>
-      <a href="games.html">Games</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-  </div>
-</header>
+  <div data-include="header"></div>
 
 <main role="main">
   <section class="hero">
@@ -51,15 +39,7 @@
   </section>
 </main>
 
-<footer class="site-footer" role="contentinfo">
-  <div class="container foot">
-    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
-    <nav class="foot-links" aria-label="Footer">
-      <a href="contact.html">Contact</a>
-      <a href="privacy.html">Privacy</a>
-      <a class="active" href="accessibility.html">Accessibility</a>
-    </nav>
-  </div>
-</footer>
+  <div data-include="footer"></div>
+  <script src="assets/partials.js"></script>
 </body>
 </html>

--- a/assets/partials.js
+++ b/assets/partials.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const includes = document.querySelectorAll('[data-include]');
+  includes.forEach(el => {
+    const name = el.getAttribute('data-include');
+    fetch(`partials/${name}.html`)
+      .then(resp => resp.text())
+      .then(html => {
+        el.outerHTML = html;
+        if (name === 'header') {
+          const current = window.location.pathname.split('/').pop() || 'index.html';
+          document.querySelectorAll('.menu a').forEach(link => {
+            if (link.getAttribute('href') === current) {
+              link.classList.add('active');
+            }
+          });
+        }
+      })
+      .catch(err => console.error('Error loading partial', name, err));
+  });
+});
+

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -1,14 +1,14 @@
 :root{
   --brand:#ff6a00; /* your orange */
   --brand-dark:#cc5200;
-  --ink:#0f0f0f;
-  --ink-dim:#4a4a4a;
-  --bg:#ffffff;
-  --bg-muted:#faf8f6;
-  --card:#ffffff;
+  --ink:#f5f5f5;
+  --ink-dim:#bbbbbb;
+  --bg:#0f0f0f;
+  --bg-muted:#1a1a1a;
+  --card:#1a1a1a;
   --ring: rgba(255,106,0,.45);
   --radius:18px;
-  --shadow: 0 8px 28px rgba(0,0,0,.10);
+  --shadow: 0 8px 28px rgba(0,0,0,.5);
   --space-1:.5rem; --space-2:.75rem; --space-3:1rem; --space-4:1.5rem; --space-5:2rem; --space-6:3rem;
 }
 html{box-sizing:border-box}*,*:before,*:after{box-sizing:inherit}
@@ -19,7 +19,7 @@ a:focus-visible,button:focus-visible{box-shadow:0 0 0 3px var(--ring); border-ra
 .container{max-width:1120px; margin:auto; padding:0 var(--space-3)}
 
 /* Header / Nav */
-.site-header{position:sticky; top:0; background:#fff; border-bottom:1px solid #eee; z-index:50; backdrop-filter:saturate(1.2) blur(4px)}
+.site-header{position:sticky; top:0; background:var(--bg); border-bottom:1px solid #222; z-index:50; backdrop-filter:saturate(1.2) blur(4px)}
 .nav{display:flex; align-items:center; gap:var(--space-3); padding:var(--space-3) 0}
 .brand{display:flex; align-items:center; gap:.65rem; text-decoration:none; color:var(--ink); font-weight:800}
 .brand img{width:44px; height:44px}
@@ -30,8 +30,8 @@ a:focus-visible,button:focus-visible{box-shadow:0 0 0 3px var(--ring); border-ra
 /* Hero: immersive panther background */
 .hero{
   position:relative; isolation:isolate; padding: clamp(3rem, 6vw, 6rem) 0;
-  background: radial-gradient(1200px 600px at 20% -10%, rgba(255,106,0,.12), transparent 60%),
-              linear-gradient(180deg, #fff, #fff);
+    background: radial-gradient(1200px 600px at 20% -10%, rgba(255,106,0,.25), transparent 60%),
+                linear-gradient(180deg, var(--bg), var(--bg));
 }
 .hero::before{
   content:""; position:absolute; inset:0; z-index:-2;
@@ -43,30 +43,30 @@ a:focus-visible,button:focus-visible{box-shadow:0 0 0 3px var(--ring); border-ra
   background: linear-gradient(180deg, rgba(0,0,0,.20), rgba(0,0,0,0) 60%);
   mix-blend-mode:multiply;
 }
-.hero h1{margin:0 0 .35rem; font-size:clamp(30px, 5.2vw, 56px); letter-spacing:.3px; color:#111}
+  .hero h1{margin:0 0 .35rem; font-size:clamp(30px, 5.2vw, 56px); letter-spacing:.3px; color:var(--ink)}
 .hero .energy-bar{width:90px; height:4px; border-radius:999px; background:var(--brand); margin:.25rem 0 var(--space-3); overflow:hidden; position:relative}
 .hero .energy-bar::after{content:""; position:absolute; inset:0; transform:translateX(-100%); background:linear-gradient(90deg, transparent, #fff8, transparent); animation: sweep 2.2s ease-in-out infinite}
 @keyframes sweep{50%{transform:translateX(0)} 100%{transform:translateX(100%)}}
-.hero .subtitle{margin:0 0 var(--space-4); color:#222; max-width:60ch}
+  .hero .subtitle{margin:0 0 var(--space-4); color:var(--ink-dim); max-width:60ch}
 .cta-row{display:flex; flex-wrap:wrap; gap:var(--space-2)}
 
 /* Sections & angled dividers */
 .section{padding: var(--space-6) 0; position:relative}
-.angle-bottom{--cut: 5vw; clip-path: polygon(0 0, 100% var(--cut), 100% 100%, 0 100%); background:#fff}
+  .angle-bottom{--cut: 5vw; clip-path: polygon(0 0, 100% var(--cut), 100% 100%, 0 100%); background:var(--bg)}
 
 /* Buttons */
-.btn{display:inline-block; padding:.85rem 1.1rem; border-radius:999px; border:1px solid #ddd; text-decoration:none; color:var(--ink); transition:transform .12s ease, box-shadow .12s ease}
+  .btn{display:inline-block; padding:.85rem 1.1rem; border-radius:999px; border:1px solid #444; text-decoration:none; color:var(--ink); transition:transform .12s ease, box-shadow .12s ease}
 .btn.primary{background:var(--brand); border-color:var(--brand); color:#fff}
 .btn:hover{transform:translateY(-1px); box-shadow:0 10px 30px rgba(255,106,0,.25)}
 
 /* Announcements */
 .announcements{list-style:none; padding:0; margin:var(--space-3) 0 0; display:grid; gap:var(--space-2)}
-.announcements li{background:var(--card); border:1px solid #eee; border-radius:16px; padding:var(--space-3); display:flex; gap:1rem; align-items:flex-start; box-shadow: var(--shadow)}
-.announcements time{background:var(--bg-muted); border-radius:999px; padding:.25rem .6rem; font-variant-numeric: tabular-nums; color:var(--ink); white-space:nowrap}
+  .announcements li{background:var(--card); border:1px solid #222; border-radius:16px; padding:var(--space-3); display:flex; gap:1rem; align-items:flex-start; box-shadow: var(--shadow)}
+  .announcements time{background:var(--bg-muted); border-radius:999px; padding:.25rem .6rem; font-variant-numeric: tabular-nums; color:var(--ink); white-space:nowrap}
 
 /* Cards */
 .grid{display:grid; gap:var(--space-3); grid-template-columns: repeat(12, 1fr)}
-.card{grid-column: span 12; padding:var(--space-4); border:1px solid #eee; border-radius:var(--radius); box-shadow:var(--shadow); background:var(--card); position:relative}
+  .card{grid-column: span 12; padding:var(--space-4); border:1px solid #222; border-radius:var(--radius); box-shadow:var(--shadow); background:var(--card); position:relative}
 .card:hover{transform:translateY(-2px); box-shadow: 0 18px 42px rgba(255,106,0,.18)}
 .card h3{margin:.25rem 0 .5rem; font-size:1.28rem}
 .card p{margin:0 0 var(--space-3); color:var(--ink-dim)}
@@ -74,11 +74,11 @@ a:focus-visible,button:focus-visible{box-shadow:0 0 0 3px var(--ring); border-ra
 @media(min-width:1024px){ .card{grid-column: span 4} }
 
 /* Footer */
-.site-footer{border-top:1px solid #eee; background:
-  radial-gradient(600px 300px at 80% 0%, rgba(255,106,0,.08), transparent 70%),
-  #fff;
+.site-footer{border-top:1px solid #222; background:
+  radial-gradient(600px 300px at 80% 0%, rgba(255,106,0,.12), transparent 70%),
+  var(--bg);
 }
-.foot{display:flex; flex-wrap:wrap; align-items:center; gap:var(--space-3); padding:var(--space-5) 0; color:#666}
+.foot{display:flex; flex-wrap:wrap; align-items:center; gap:var(--space-3); padding:var(--space-5) 0; color:var(--ink-dim)}
 .foot-links{margin-left:auto; display:flex; gap:var(--space-3)}
-.foot a{color:#666; text-decoration:none}
+.foot a{color:var(--ink-dim); text-decoration:none}
 .foot a:hover{color:var(--ink)}

--- a/circuit-game.html
+++ b/circuit-game.html
@@ -9,19 +9,7 @@
   <link rel="stylesheet" href="assets/theme.css"/>
 </head>
 <body>
-<header class="site-header" role="banner">
-  <div class="container nav">
-    <a class="brand" href="index.html"><img src="panther-logo.svg" alt="Orange High Panthers logo"><span>Mr. Mudry’s Physics</span></a>
-    <nav class="menu" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="lesson-plans.html">Lesson Plans</a>
-      <a href="resources.html">Resources</a>
-      <a class="active" href="circuit-game.html">Circuit Game</a>
-      <a href="games.html">Games</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-  </div>
-</header>
+  <div data-include="header"></div>
 
 <main role="main">
   <section class="hero">
@@ -46,15 +34,7 @@
   </section>
 </main>
 
-<footer class="site-footer" role="contentinfo">
-  <div class="container foot">
-    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
-    <nav class="foot-links" aria-label="Footer">
-      <a href="contact.html">Contact</a>
-      <a href="privacy.html">Privacy</a>
-      <a href="accessibility.html">Accessibility</a>
-    </nav>
-  </div>
-</footer>
+  <div data-include="footer"></div>
+  <script src="assets/partials.js"></script>
 </body>
 </html>

--- a/circuit_symbol_game.html
+++ b/circuit_symbol_game.html
@@ -4,20 +4,22 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Electronic Symbols Quiz Game</title>
+  <link rel="stylesheet" href="assets/theme.css"/>
   <style>
     body {
       font-family: Arial, sans-serif;
-      background: #f5f5f5;
+      background: var(--bg);
+      color: var(--ink);
       margin: 0;
       padding: 2rem;
     }
     #game {
       max-width: 500px;
       margin: auto;
-      background: #fff;
+      background: var(--card);
       padding: 1.5rem;
       border-radius: 10px;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+      box-shadow: 0 2px 6px rgba(0,0,0,0.4);
       text-align: center;
     }
     #symbol svg {
@@ -34,16 +36,17 @@
       border: none;
       border-radius: 5px;
       cursor: pointer;
-      background: #e0e0e0;
+      background: var(--bg-muted);
+      color: var(--ink);
     }
     .option-btn:hover {
-      background: #d5d5d5;
+      background: #333;
     }
     .correct {
-      background: #a5d6a7 !important;
+      background: #2e7d32 !important;
     }
     .incorrect {
-      background: #ef9a9a !important;
+      background: #c62828 !important;
     }
     #progress {
       margin-top: 1rem;
@@ -52,6 +55,7 @@
   </style>
 </head>
 <body>
+  <div data-include="header"></div>
   <div id="game">
     <h1>Electronic Symbols Quiz</h1>
     <div id="symbol"></div>
@@ -59,6 +63,8 @@
     <div id="progress"></div>
   </div>
 
+  <div data-include="footer"></div>
+  <script src="assets/partials.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       // List of symbols and their SVG representations

--- a/contact.html
+++ b/contact.html
@@ -9,19 +9,7 @@
   <link rel="stylesheet" href="assets/theme.css"/>
 </head>
 <body>
-<header class="site-header" role="banner">
-  <div class="container nav">
-    <a class="brand" href="index.html"><img src="panther-logo.svg" alt="Orange High Panthers logo"><span>Mr. Mudry’s Physics</span></a>
-    <nav class="menu" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="lesson-plans.html">Lesson Plans</a>
-      <a href="resources.html">Resources</a>
-      <a href="circuit-game.html">Circuit Game</a>
-      <a href="games.html">Games</a>
-      <a class="active" href="contact.html">Contact</a>
-    </nav>
-  </div>
-</header>
+  <div data-include="header"></div>
 
 <main role="main">
   <section class="hero">
@@ -51,15 +39,7 @@
   </section>
 </main>
 
-<footer class="site-footer" role="contentinfo">
-  <div class="container foot">
-    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
-    <nav class="foot-links" aria-label="Footer">
-      <a href="contact.html">Contact</a>
-      <a href="privacy.html">Privacy</a>
-      <a href="accessibility.html">Accessibility</a>
-    </nav>
-  </div>
-</footer>
+  <div data-include="footer"></div>
+  <script src="assets/partials.js"></script>
 </body>
 </html>

--- a/games.html
+++ b/games.html
@@ -9,19 +9,7 @@
   <link rel="stylesheet" href="assets/theme.css"/>
 </head>
 <body>
-<header class="site-header" role="banner">
-  <div class="container nav">
-    <a class="brand" href="index.html"><img src="panther-logo.svg" alt="Orange High Panthers logo"><span>Mr. Mudry’s Physics</span></a>
-    <nav class="menu" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="lesson-plans.html">Lesson Plans</a>
-      <a href="resources.html">Resources</a>
-      <a href="circuit-game.html">Circuit Game</a>
-      <a class="active" href="games.html">Games</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-  </div>
-</header>
+  <div data-include="header"></div>
 
 <main role="main">
   <section class="hero">
@@ -63,15 +51,7 @@
   </section>
 </main>
 
-<footer class="site-footer" role="contentinfo">
-  <div class="container foot">
-    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
-    <nav class="foot-links" aria-label="Footer">
-      <a href="contact.html">Contact</a>
-      <a href="privacy.html">Privacy</a>
-      <a href="accessibility.html">Accessibility</a>
-    </nav>
-  </div>
-</footer>
+  <div data-include="footer"></div>
+  <script src="assets/partials.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,19 +9,7 @@
   <link rel="stylesheet" href="assets/theme.css"/>
 </head>
 <body>
-<header class="site-header" role="banner">
-  <div class="container nav">
-    <a class="brand" href="index.html"><img src="panther-logo.svg" alt="Orange High Panthers logo"><span>Mr. Mudry’s Physics</span></a>
-    <nav class="menu" aria-label="Primary">
-      <a class="active" href="index.html">Home</a>
-      <a href="lesson-plans.html">Lesson Plans</a>
-      <a href="resources.html">Resources</a>
-      <a href="circuit-game.html">Circuit Game</a>
-      <a href="games.html">Games</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-  </div>
-</header>
+  <div data-include="header"></div>
 
 <main role="main">
   <section class="hero">
@@ -67,15 +55,7 @@
   </section>
 </main>
 
-<footer class="site-footer" role="contentinfo">
-  <div class="container foot">
-    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
-    <nav class="foot-links" aria-label="Footer">
-      <a href="contact.html">Contact</a>
-      <a href="privacy.html">Privacy</a>
-      <a href="accessibility.html">Accessibility</a>
-    </nav>
-  </div>
-</footer>
+  <div data-include="footer"></div>
+  <script src="assets/partials.js"></script>
 </body>
 </html>

--- a/lesson-plans.html
+++ b/lesson-plans.html
@@ -9,19 +9,7 @@
   <link rel="stylesheet" href="assets/theme.css"/>
 </head>
 <body>
-<header class="site-header" role="banner">
-  <div class="container nav">
-    <a class="brand" href="index.html"><img src="panther-logo.svg" alt="Orange High Panthers logo"><span>Mr. Mudry’s Physics</span></a>
-    <nav class="menu" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a class="active" href="lesson-plans.html">Lesson Plans</a>
-      <a href="resources.html">Resources</a>
-      <a href="circuit-game.html">Circuit Game</a>
-      <a href="games.html">Games</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-  </div>
-</header>
+  <div data-include="header"></div>
 
 <main role="main">
   <section class="hero">
@@ -58,15 +46,7 @@
   </section>
 </main>
 
-<footer class="site-footer" role="contentinfo">
-  <div class="container foot">
-    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
-    <nav class="foot-links" aria-label="Footer">
-      <a href="contact.html">Contact</a>
-      <a href="privacy.html">Privacy</a>
-      <a href="accessibility.html">Accessibility</a>
-    </nav>
-  </div>
-</footer>
+  <div data-include="footer"></div>
+  <script src="assets/partials.js"></script>
 </body>
 </html>

--- a/lessons.html
+++ b/lessons.html
@@ -9,19 +9,7 @@
   <link rel="stylesheet" href="assets/theme.css"/>
 </head>
 <body>
-<header class="site-header" role="banner">
-  <div class="container nav">
-    <a class="brand" href="index.html"><img src="panther-logo.svg" alt="Orange High Panthers logo"><span>Mr. Mudry’s Physics</span></a>
-    <nav class="menu" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="lesson-plans.html">Lesson Plans</a>
-      <a href="resources.html">Resources</a>
-      <a href="circuit-game.html">Circuit Game</a>
-      <a href="games.html">Games</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-  </div>
-</header>
+  <div data-include="header"></div>
 
 <main role="main">
   <section class="hero">
@@ -54,15 +42,7 @@
   </section>
 </main>
 
-<footer class="site-footer" role="contentinfo">
-  <div class="container foot">
-    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
-    <nav class="foot-links" aria-label="Footer">
-      <a href="contact.html">Contact</a>
-      <a href="privacy.html">Privacy</a>
-      <a href="accessibility.html">Accessibility</a>
-    </nav>
-  </div>
-</footer>
+  <div data-include="footer"></div>
+  <script src="assets/partials.js"></script>
 </body>
 </html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,11 @@
+<footer class="site-footer" role="contentinfo">
+  <div class="container foot">
+    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
+    <nav class="foot-links" aria-label="Footer">
+      <a href="contact.html">Contact</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="accessibility.html">Accessibility</a>
+    </nav>
+  </div>
+</footer>
+

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,14 @@
+<header class="site-header" role="banner">
+  <div class="container nav">
+    <a class="brand" href="index.html"><img src="panther-logo.svg" alt="Orange High Panthers logo"><span>Mr. Mudry’s Physics</span></a>
+    <nav class="menu" aria-label="Primary">
+      <a href="index.html">Home</a>
+      <a href="lesson-plans.html">Lesson Plans</a>
+      <a href="resources.html">Resources</a>
+      <a href="circuit-game.html">Circuit Game</a>
+      <a href="games.html">Games</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </div>
+</header>
+

--- a/privacy.html
+++ b/privacy.html
@@ -9,19 +9,7 @@
   <link rel="stylesheet" href="assets/theme.css"/>
 </head>
 <body>
-<header class="site-header" role="banner">
-  <div class="container nav">
-    <a class="brand" href="index.html"><img src="panther-logo.svg" alt="Orange High Panthers logo"><span>Mr. Mudry’s Physics</span></a>
-    <nav class="menu" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="lesson-plans.html">Lesson Plans</a>
-      <a href="resources.html">Resources</a>
-      <a href="circuit-game.html">Circuit Game</a>
-      <a href="games.html">Games</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-  </div>
-</header>
+  <div data-include="header"></div>
 
 <main role="main">
   <section class="hero">
@@ -51,15 +39,7 @@
   </section>
 </main>
 
-<footer class="site-footer" role="contentinfo">
-  <div class="container foot">
-    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
-    <nav class="foot-links" aria-label="Footer">
-      <a href="contact.html">Contact</a>
-      <a class="active" href="privacy.html">Privacy</a>
-      <a href="accessibility.html">Accessibility</a>
-    </nav>
-  </div>
-</footer>
+  <div data-include="footer"></div>
+  <script src="assets/partials.js"></script>
 </body>
 </html>

--- a/resources.html
+++ b/resources.html
@@ -9,19 +9,7 @@
   <link rel="stylesheet" href="assets/theme.css"/>
 </head>
 <body>
-<header class="site-header" role="banner">
-  <div class="container nav">
-    <a class="brand" href="index.html"><img src="panther-logo.svg" alt="Orange High Panthers logo"><span>Mr. Mudry’s Physics</span></a>
-    <nav class="menu" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="lesson-plans.html">Lesson Plans</a>
-      <a class="active" href="resources.html">Resources</a>
-      <a href="circuit-game.html">Circuit Game</a>
-      <a href="games.html">Games</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-  </div>
-</header>
+  <div data-include="header"></div>
 
 <main role="main">
   <section class="hero">
@@ -43,15 +31,7 @@
   </section>
 </main>
 
-<footer class="site-footer" role="contentinfo">
-  <div class="container foot">
-    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
-    <nav class="foot-links" aria-label="Footer">
-      <a href="contact.html">Contact</a>
-      <a href="privacy.html">Privacy</a>
-      <a href="accessibility.html">Accessibility</a>
-    </nav>
-  </div>
-</footer>
+  <div data-include="footer"></div>
+  <script src="assets/partials.js"></script>
 </body>
 </html>

--- a/unit1.html
+++ b/unit1.html
@@ -9,19 +9,7 @@
   <link rel="stylesheet" href="assets/theme.css"/>
 </head>
 <body>
-<header class="site-header" role="banner">
-  <div class="container nav">
-    <a class="brand" href="index.html"><img src="panther-logo.svg" alt="Orange High Panthers logo"><span>Mr. Mudry’s Physics</span></a>
-    <nav class="menu" aria-label="Primary">
-      <a href="index.html">Home</a>
-      <a href="lesson-plans.html">Lesson Plans</a>
-      <a href="resources.html">Resources</a>
-      <a href="circuit-game.html">Circuit Game</a>
-      <a href="games.html">Games</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-  </div>
-</header>
+  <div data-include="header"></div>
 
 <main role="main">
   <section class="hero">
@@ -54,15 +42,7 @@
   </section>
 </main>
 
-<footer class="site-footer" role="contentinfo">
-  <div class="container foot">
-    <p>© 2025 Mr. Mudry • Orange High School Panthers</p>
-    <nav class="foot-links" aria-label="Footer">
-      <a href="contact.html">Contact</a>
-      <a href="privacy.html">Privacy</a>
-      <a href="accessibility.html">Accessibility</a>
-    </nav>
-  </div>
-</footer>
+  <div data-include="footer"></div>
+  <script src="assets/partials.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- centralize navigation and footer into reusable partials
- add script to inject partials and highlight the active page
- switch to a dark black-and-orange palette and update circuit symbol game to match

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0dd266b34832098ea1581dc0d8d54