### PR TITLE
Add Eureka! video gallery

### DIFF
--- a/eureka-videos.html
+++ b/eureka-videos.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Eureka! Videos • Mr. Mudry’s Physics</title>
+  <link rel="icon" type="image/png" href="head.png"/>
+  <link rel="apple-touch-icon" href="apple-touch-icon.svg"/>
+  <link rel="stylesheet" href="assets/theme.css"/>
+</head>
+<body>
+  <div data-include="header"></div>
+
+<main role="main">
+  <section class="hero">
+    <div class="container">
+      <h1>Eureka! Videos</h1>
+      <div class="energy-bar" aria-hidden="true"></div>
+      <p class="subtitle">Animated explanations of key physics concepts.</p>
+    </div>
+  </section>
+
+  <section class="container section angle-bottom" aria-labelledby="video-gallery">
+    <h2 id="video-gallery">Gallery</h2>
+    <div class="grid">
+      <article class="card">
+        <h3>Eureka! Episode 1 Inertia</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/5729g2yDMk0" title="Eureka! Episode 1 Inertia" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 2 Mass</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/c8TfSg6P_Lw" title="Eureka! Episode 2 Mass" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 3 Speed</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/o83-Aj2k85E" title="Eureka! Episode 3 Speed" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 4 Acceleration Part I</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/I9Db2TIy3y4" title="Eureka! Episode 4 Acceleration Part I" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 5 Acceleration Part II</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/zHnVEB_uX-I" title="Eureka! Episode 5 Acceleration Part II" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 6 Gravity</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/uD5u0LAnb2c" title="Eureka! Episode 6 Gravity" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 7 Weight vs Mass</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/GFCksPCePq0" title="Eureka! Episode 7 Weight vs Mass" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 8 Work</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/zmjbL-XrabU" title="Eureka! Episode 8 Work" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 9 Kinetic Energy</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/2yT5x6v4j4Y" title="Eureka! Episode 9 Kinetic Energy" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 10 Potential Energy</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/pVI2Kj-Ok7Y" title="Eureka! Episode 10 Potential Energy" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 11 The Inclined Plane</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/IG4fDOkcyWc" title="Eureka! Episode 11 The Inclined Plane" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 12 The Lever</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/LySej2qL-8w" title="Eureka! Episode 12 The Lever" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 13 Mechanical Advantage and Friction</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/O57ia22p7FA" title="Eureka! Episode 13 Mechanical Advantage and Friction" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 14 The Screw</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/QjzjA-2Z2oY" title="Eureka! Episode 14 The Screw" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 15 The Wheel And Axle</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/NdA4t5Jo35U" title="Eureka! Episode 15 The Wheel And Axle" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 16 The Pulley</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/YwGk01a74wU" title="Eureka! Episode 16 The Pulley" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 17 Gears</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/vjkehC5G0oI" title="Eureka! Episode 17 Gears" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 18 Density</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/Qk3Taua0I5Y" title="Eureka! Episode 18 Density" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 19 Buoyancy</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/y0SnFCs9z1w" title="Eureka! Episode 19 Buoyancy" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 20 Molecules In Solids</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/yJ35Uf5rW7A" title="Eureka! Episode 20 Molecules In Solids" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 21 Molecules in Liquids</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/oFNe-sOMv-g" title="Eureka! Episode 21 Molecules in Liquids" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 22 Molecules in Gases</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/u2N6p-_iQ2Q" title="Eureka! Episode 22 Molecules in Gases" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 23 Heat As Energy</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/Ewzk2yIq-do" title="Eureka! Episode 23 Heat As Energy" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 24 Heat and Temperature</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/T2nMk_lH4pA" title="Eureka! Episode 24 Heat and Temperature" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 25 Measurement of Heat</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/9lnao1mB-Bg" title="Eureka! Episode 25 Measurement of Heat" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 26 Heat Transfer</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/2hM0LgPfL-o" title="Eureka! Episode 26 Heat Transfer" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 27 The Steam Engine</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/27EtrRz3Q1M" title="Eureka! Episode 27 The Steam Engine" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 28 The Internal Combustion Engine</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/sYk0uTjoF34" title="Eureka! Episode 28 The Internal Combustion Engine" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 29 Refrigeration</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/Y9tT4ASqZ3I" title="Eureka! Episode 29 Refrigeration" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+      <article class="card">
+        <h3>Eureka! Episode 30 Heat as Power</h3>
+        <iframe width="100%" height="315" src="https://www.youtube.com/embed/YfH2yqjW9eM" title="Eureka! Episode 30 Heat as Power" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </article>
+    </div>
+  </section>
+</main>
+
+  <div data-include="footer"></div>
+  <script src="assets/partials.js"></script>
+</body>
+</html>

--- a/partials/header.html
+++ b/partials/header.html
@@ -7,6 +7,7 @@
       <a href="resources.html">Resources</a>
       <a href="circuit-game.html">Circuit Game</a>
       <a href="games.html">Games</a>
+      <a href="eureka-videos.html">Eureka! Videos</a>
       <a href="contact.html">Contact</a>
     </nav>
   </div>


### PR DESCRIPTION
## Summary
- add eureka-videos.html with gallery of 30 YouTube episodes from the Eureka! series
- link the gallery in the header navigation
- embed videos using standard youtube.com domain so they load correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c08bc3fa3083209321b65cf7e3235c