### PR TITLE
Align time units with speed units in speed calculator questions

### DIFF
--- a/physics-speed-calculator/data/questions.json
+++ b/physics-speed-calculator/data/questions.json
@@ -60,8 +60,8 @@
         },
         {
           "id": "q2v2",
-          "value": 3.5,
-          "unit": "min",
+          "value": 0.058333333333333334,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -94,8 +94,8 @@
         },
         {
           "id": "q3v2",
-          "value": 12,
-          "unit": "min",
+          "value": 0.2,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -162,8 +162,8 @@
         },
         {
           "id": "q5v2",
-          "value": 18,
-          "unit": "min",
+          "value": 0.3,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -196,8 +196,8 @@
         },
         {
           "id": "q6v2",
-          "value": 26,
-          "unit": "min",
+          "value": 0.43333333333333335,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -230,8 +230,8 @@
         },
         {
           "id": "q7v2",
-          "value": 18,
-          "unit": "min",
+          "value": 0.3,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -264,8 +264,8 @@
         },
         {
           "id": "q8v2",
-          "value": 22,
-          "unit": "min",
+          "value": 0.36666666666666664,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -332,8 +332,8 @@
         },
         {
           "id": "q10v2",
-          "value": 48,
-          "unit": "min",
+          "value": 0.8,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -366,8 +366,8 @@
         },
         {
           "id": "q11v2",
-          "value": 42,
-          "unit": "min",
+          "value": 0.7,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -400,8 +400,8 @@
         },
         {
           "id": "q12v2",
-          "value": 50,
-          "unit": "min",
+          "value": 0.8333333333333334,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -434,8 +434,8 @@
         },
         {
           "id": "q13v2",
-          "value": 32,
-          "unit": "min",
+          "value": 0.5333333333333333,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -468,8 +468,8 @@
         },
         {
           "id": "q14v2",
-          "value": 40,
-          "unit": "min",
+          "value": 0.6666666666666666,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -502,8 +502,8 @@
         },
         {
           "id": "q15v2",
-          "value": 12,
-          "unit": "min",
+          "value": 0.2,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -570,8 +570,8 @@
         },
         {
           "id": "q17v2",
-          "value": 21,
-          "unit": "min",
+          "value": 0.35,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -604,8 +604,8 @@
         },
         {
           "id": "q18v2",
-          "value": 18,
-          "unit": "min",
+          "value": 0.3,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -638,8 +638,8 @@
         },
         {
           "id": "q19v2",
-          "value": 28,
-          "unit": "min",
+          "value": 0.4666666666666667,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -672,8 +672,8 @@
         },
         {
           "id": "q20v2",
-          "value": 95,
-          "unit": "min",
+          "value": 1.5833333333333333,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -808,8 +808,8 @@
         },
         {
           "id": "q24v2",
-          "value": 38,
-          "unit": "min",
+          "value": 0.6333333333333333,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -842,8 +842,8 @@
         },
         {
           "id": "q25v2",
-          "value": 48,
-          "unit": "min",
+          "value": 0.8,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -876,8 +876,8 @@
         },
         {
           "id": "q26v2",
-          "value": 95,
-          "unit": "min",
+          "value": 1.5833333333333333,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -910,8 +910,8 @@
         },
         {
           "id": "q27v2",
-          "value": 15,
-          "unit": "min",
+          "value": 900,
+          "unit": "s",
           "variable": "t"
         }
       ],
@@ -1046,8 +1046,8 @@
         },
         {
           "id": "q31v2",
-          "value": 26,
-          "unit": "min",
+          "value": 0.43333333333333335,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -1080,8 +1080,8 @@
         },
         {
           "id": "q32v2",
-          "value": 18,
-          "unit": "min",
+          "value": 0.3,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -1114,8 +1114,8 @@
         },
         {
           "id": "q33v2",
-          "value": 12,
-          "unit": "min",
+          "value": 720,
+          "unit": "s",
           "variable": "t"
         }
       ],
@@ -1148,8 +1148,8 @@
         },
         {
           "id": "q34v2",
-          "value": 28,
-          "unit": "min",
+          "value": 0.4666666666666667,
+          "unit": "h",
           "variable": "t"
         }
       ],
@@ -1182,8 +1182,8 @@
         },
         {
           "id": "q35v2",
-          "value": 45,
-          "unit": "min",
+          "value": 2700,
+          "unit": "s",
           "variable": "t"
         }
       ],


### PR DESCRIPTION
## Summary
- convert minute-based time values in the speed calculator question bank to hours or seconds so they match each problem's velocity units

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d17c32bd0c8320b18fd728e847579b