### PR TITLE
Restore site styling and link speed calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Personal classroom site with HTML5 games and lesson materials.
 
 ## Highlights
 
-- New: Physics Speed Calculator (`physics-speed-calculator/` → builds to `assets/physics-speed-calculator/`).
+- New: Physics Speed Calculator (`physics_speed_calculator/dist/index.html`).
 
 ## Local Setup
 

--- a/assets/partials.js
+++ b/assets/partials.js
@@ -1,0 +1,54 @@
+(function () {
+  const includeAttr = 'include';
+  const includeSelector = `[data-${includeAttr}]`;
+  const basePath = 'partials/';
+
+  function normalisePath(path) {
+    if (!path) return '';
+    const file = path.split('#')[0];
+    return file === '' ? 'index.html' : file;
+  }
+
+  function markActiveNav(root) {
+    if (!root) return;
+    const current = normalisePath(window.location.pathname.split('/').pop() || 'index.html');
+    root.querySelectorAll('a[href]').forEach((link) => {
+      const href = normalisePath(link.getAttribute('href'));
+      if (href && href === current) {
+        link.setAttribute('aria-current', 'page');
+      }
+    });
+  }
+
+  async function injectPartial(el) {
+    const target = el.dataset[includeAttr];
+    if (!target) return;
+    const url = `${basePath}${target}.html`;
+
+    try {
+      const response = await fetch(url, { cache: 'no-cache' });
+      if (!response.ok) {
+        throw new Error(`Failed to load ${url}: ${response.status}`);
+      }
+      const html = await response.text();
+      el.innerHTML = html;
+      if (target === 'header') {
+        markActiveNav(el);
+      }
+    } catch (error) {
+      console.error(error);
+      el.innerHTML = `<div class="include-error">Unable to load ${target}.</div>`;
+    }
+  }
+
+  async function processPartials() {
+    const nodes = document.querySelectorAll(includeSelector);
+    await Promise.all(Array.from(nodes, injectPartial));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', processPartials);
+  } else {
+    processPartials();
+  }
+})();

--- a/assets/scoreboard.js
+++ b/assets/scoreboard.js
@@ -1,0 +1,93 @@
+(function () {
+  const STORAGE_KEY = 'mr-mudry-scoreboard';
+
+  function getStorage() {
+    try {
+      const testKey = '__scoreboard_test__';
+      window.localStorage.setItem(testKey, '1');
+      window.localStorage.removeItem(testKey);
+      return window.localStorage;
+    } catch (error) {
+      console.warn('Scoreboard: localStorage unavailable, using memory store.', error);
+      return null;
+    }
+  }
+
+  const storage = getStorage();
+  let memoryStore = {};
+
+  function readStore() {
+    if (!storage) {
+      return { ...memoryStore };
+    }
+    try {
+      const raw = storage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : {};
+    } catch (error) {
+      console.error('Scoreboard: failed to read store.', error);
+      return {};
+    }
+  }
+
+  function writeStore(data) {
+    if (!storage) {
+      memoryStore = { ...data };
+      return;
+    }
+    try {
+      storage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch (error) {
+      console.error('Scoreboard: failed to save store.', error);
+    }
+  }
+
+  function normaliseName(name) {
+    const value = (name || 'Player').toString().trim();
+    return value.length > 48 ? value.slice(0, 48) : value;
+  }
+
+  function ensureGame(data, game) {
+    if (!data[game]) {
+      data[game] = {};
+    }
+    return data[game];
+  }
+
+  const api = {
+    addWin(game, playerName) {
+      if (!game) return;
+      const data = readStore();
+      const gameStore = ensureGame(data, game);
+      const name = normaliseName(playerName);
+      gameStore[name] = (gameStore[name] || 0) + 1;
+      writeStore(data);
+    },
+
+    getTop(game, limit = 5) {
+      if (!game) return [];
+      const data = readStore();
+      const gameStore = data[game] || {};
+      return Object.entries(gameStore)
+        .sort(([, aWins], [, bWins]) => bWins - aWins || 0)
+        .slice(0, Math.max(0, limit));
+    },
+
+    clear(game) {
+      if (!game) {
+        writeStore({});
+        return;
+      }
+      const data = readStore();
+      if (data[game]) {
+        delete data[game];
+        writeStore(data);
+      }
+    },
+
+    _dump() {
+      return readStore();
+    },
+  };
+
+  window.Scoreboard = api;
+})();

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -1,0 +1,441 @@
+:root {
+  --bg: #070b1a;
+  --bg-alt: #0e1328;
+  --surface: rgba(13, 19, 40, 0.85);
+  --surface-solid: #151b34;
+  --border: rgba(120, 141, 255, 0.16);
+  --text: #f8fafc;
+  --text-muted: #cbd5f5;
+  --accent: #f97316;
+  --accent-soft: #fb923c;
+  --accent-strong: #ea580c;
+  --shadow: 0 24px 60px rgba(6, 13, 30, 0.45);
+  --radius-lg: 22px;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+  --max-width: min(1080px, 92vw);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+  background: radial-gradient(circle at top left, rgba(249, 115, 22, 0.12), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(59, 130, 246, 0.12), transparent 50%),
+    linear-gradient(160deg, #050810 0%, #060b18 45%, #030510 100%);
+  color: var(--text);
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+a {
+  color: var(--accent-soft);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent);
+}
+
+main {
+  flex: 1 0 auto;
+}
+
+.container {
+  width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.25rem;
+}
+
+.site-header {
+  background: rgba(5, 10, 24, 0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+.site-header .nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.25rem 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 700;
+  font-size: 1.35rem;
+  letter-spacing: 0.04em;
+  color: var(--text);
+}
+
+.brand span {
+  white-space: nowrap;
+}
+
+.brand img {
+  height: 52px;
+  width: auto;
+}
+
+.menu {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.menu a {
+  color: var(--text-muted);
+  font-weight: 600;
+  position: relative;
+  padding-bottom: 0.25rem;
+  transition: color 0.2s ease;
+}
+
+.menu a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+  background: linear-gradient(90deg, var(--accent), var(--accent-soft));
+}
+
+.menu a:hover,
+.menu a:focus {
+  color: var(--text);
+}
+
+.menu a:hover::after,
+.menu a:focus::after,
+.menu a[aria-current="page"]::after {
+  transform: scaleX(1);
+}
+
+.menu a[aria-current="page"] {
+  color: var(--text);
+}
+
+.hero {
+  padding: clamp(4rem, 8vw, 7rem) 0;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top center, rgba(249, 115, 22, 0.16), transparent 65%);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.hero .container {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.75rem, 5vw, 3.75rem);
+  font-weight: 800;
+  letter-spacing: 0.01em;
+  margin: 0;
+}
+
+.subtitle {
+  color: var(--text-muted);
+  max-width: 52ch;
+  margin: 0 auto;
+  font-size: 1.1rem;
+}
+
+.energy-bar {
+  width: clamp(180px, 18vw, 260px);
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-soft) 50%, #facc15 100%);
+  box-shadow: 0 0 20px rgba(249, 115, 22, 0.45);
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.35rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28);
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-soft) 100%);
+  color: #0a0a0a;
+  border: none;
+}
+
+.btn.primary:hover,
+.btn.primary:focus-visible {
+  background: linear-gradient(135deg, var(--accent-strong), var(--accent));
+  color: #050505;
+}
+
+.section {
+  padding: clamp(3rem, 7vw, 4.5rem) 0;
+  background: rgba(5, 10, 20, 0.45);
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.section h2 {
+  font-size: clamp(2rem, 3vw, 2.4rem);
+  margin-bottom: 1.75rem;
+  letter-spacing: 0.01em;
+}
+
+.angle-bottom {
+  position: relative;
+  overflow: hidden;
+}
+
+.angle-bottom::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 -60px 0;
+  height: 120px;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.55) 100%);
+  transform: skewY(-5deg);
+  pointer-events: none;
+}
+
+.announcements {
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+}
+
+.announcements li {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 1.1rem 1.3rem;
+  display: flex;
+  gap: 0.85rem;
+  align-items: center;
+  box-shadow: var(--shadow);
+}
+
+.announcements time {
+  font-weight: 700;
+  color: var(--accent-soft);
+  letter-spacing: 0.08em;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.card:hover,
+.card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 28px 60px rgba(10, 12, 35, 0.55);
+  border-color: rgba(249, 115, 22, 0.45);
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.card p {
+  margin: 0 0 0.5rem;
+  color: var(--text-muted);
+}
+
+.card .btn {
+  align-self: flex-start;
+}
+
+.site-footer {
+  background: rgba(5, 9, 20, 0.9);
+  border-top: 1px solid var(--border);
+  padding: 2rem 0;
+}
+
+.site-footer .foot {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.foot-links {
+  display: flex;
+  gap: 1.2rem;
+}
+
+.foot-links a {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.foot-links a:hover,
+.foot-links a:focus {
+  color: var(--text);
+}
+
+#scoreboard {
+  display: grid;
+  gap: 1.25rem;
+}
+
+#scoreboard h3 {
+  margin-bottom: 0.4rem;
+}
+
+#scoreboard ol {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+#include-error,
+.include-error {
+  color: #fca5a5;
+  font-size: 0.95rem;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+}
+
+@media (max-width: 900px) {
+  .site-header .nav {
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 1.1rem 0;
+  }
+
+  .brand {
+    font-size: 1.2rem;
+  }
+
+  .brand img {
+    height: 44px;
+  }
+
+  .menu {
+    width: 100%;
+    justify-content: space-between;
+    gap: 0.85rem 1.25rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .menu {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero {
+    text-align: left;
+  }
+
+  .hero .container {
+    align-items: flex-start;
+  }
+
+  .cta-row {
+    justify-content: flex-start;
+  }
+
+  .site-footer .foot {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .foot-links {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
       <article class="card">
         <h3>🚀 Speed Calculator</h3>
         <p>Drag and drop values to solve velocity, distance, and time puzzles.</p>
-        <a class="btn" href="assets/physics-speed-calculator/index.html">Launch App</a>
+        <a class="btn" href="physics_speed_calculator/dist/index.html">Launch App</a>
       </article>
       <article class="card">
         <h3>Extra Resources</h3>


### PR DESCRIPTION
## Summary
- add a new site theme stylesheet and partial loader so shared layout renders again
- provide a reusable scoreboard helper for the arcade pages
- update the speed calculator link on the homepage and in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2628cca44832088c158169efb2996