### PR TITLE
Update touch icon and add hero illustration

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -159,6 +159,26 @@ main {
   pointer-events: none;
 }
 
+.hero::after {
+  content: "";
+  position: absolute;
+  top: clamp(0.5rem, 2vw, 2rem);
+  right: clamp(0.5rem, 2vw, 2rem);
+  width: min(320px, 36vw);
+  aspect-ratio: 1;
+  background: url("../Fixed_Physics.png") no-repeat center/contain;
+  opacity: 0.55;
+  filter: drop-shadow(0 12px 30px rgba(3, 6, 16, 0.6));
+  pointer-events: none;
+}
+
+@media (max-width: 600px) {
+  .hero::after {
+    opacity: 0.4;
+    width: min(220px, 60vw);
+  }
+}
+
 .hero .container {
   position: relative;
   z-index: 1;

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Mr. Mudry’s Physics • Home</title>
   <link rel="icon" type="image/png" href="head.png"/>
-  <link rel="apple-touch-icon" href="apple-touch-icon.svg"/>
+  <link rel="apple-touch-icon" href="head.png"/>
   <link rel="stylesheet" href="assets/theme.css"/>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- point the Apple touch icon to `head.png` so the site icon is consistent across devices
- layer the `Fixed_Physics.png` artwork into the hero section as a decorative, responsive accent

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd518671c48320a6245ef6481195f7